### PR TITLE
feat(extensions): add READMEs

### DIFF
--- a/apps/miranum-console/README.md
+++ b/apps/miranum-console/README.md
@@ -32,16 +32,15 @@ process application in one place.
 Please find our official docs [here](https://miranum.com/docs/components/miranum-ide/intro-miranum-ide).
 
 
-The Miranum Modeler is one component of our collection of *VS Code Plugins*.
-It allows you to model BPMN 2.0 Diagrams that can be used with Camunda Platform 7.
+The Miranum Console is one component of our collection of *VS Code Plugins*.
+It provides a UI and helps you to scaffold your digitization project and deploy process artefacts.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ## Features
 
-* Create and edit processes for Camunda Platform 7 and enhance them with technical attributes.
-* Use the text editor for changes directly in the XML file.
-* Use the integrated *Token Simulation* to simulate your process flow.
+* Scaffolding your digitization project.
+* Deploy your process artefacts.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -49,7 +48,8 @@ It allows you to model BPMN 2.0 Diagrams that can be used with Camunda Platform 
 
 The documentation project is built with technologies we use in our projects:
 
-* [BPMN.io](https://bpmn.io/toolkit/bpmn-js/)
+* [Miranum CLI](https://www.npmjs.com/package/@miragon/miranum-cli)
+* [React](https://react.dev/)
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/apps/miranum-console/package.json
+++ b/apps/miranum-console/package.json
@@ -1,10 +1,15 @@
 {
   "name": "miranum-console",
 	"displayName": "Miranum: Console",
-  "version": "0.1.0",
-  "description": "",
+  "description": "A beautiful UI to deploy your process artefacts.",
   "license": "Apache-2.0",
+  "version": "0.1.0",
   "publisher": "miragon-gmbh",
+  "homepage": "https://www.miranum.io/",
+  "galleryBanner": {
+    "color": "#4254E2",
+    "theme": "dark"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/FlowSquad/miranum-ide.git"
@@ -19,10 +24,16 @@
 	"categories": [
 		"Other"
 	],
-	"extensionPack": [
-	  "publisher.extensionName"
-	],
-	"activationEvents": [
+  "extensionPack": [
+    "miragon-gmbh.miranum-console",
+    "miragon-gmbh.miranum-json-forms",
+    "miragon-gmbh.miranum-vs-code-forms",
+    "miragon-gmbh.vs-code-bpmn-modeler"
+  ],
+  "keywords": [
+    "deploy", "Deployment", "CLI", "fontend"
+  ],
+  "activationEvents": [
         "onCommand:miranum.deploy.local",
         "onCommand:miranum.deploy.dev",
         "onCommand:miranum.deploy.test",

--- a/apps/miranum-console/project.json
+++ b/apps/miranum-console/project.json
@@ -63,8 +63,9 @@
         "assets": [
           { "glob": "images/komet.svg", "input": "./", "output": "/assets" },
           { "glob": "images/kometLogo.png", "input": "./", "output": "/assets" },
+          { "glob": "LICENSE", "input": "./", "output": "/" },
           { "glob": ".vscodeignore", "input": "./apps/miranum-console/", "output": "/" },
-          { "glob": "LICENSE", "input": "./", "output": "/" }
+          { "glob": "README.md", "input": "./apps/miranum-console/", "output": "/" }
         ]
       },
       "configurations": {

--- a/apps/miranum-forms/README.md
+++ b/apps/miranum-forms/README.md
@@ -32,24 +32,26 @@ process application in one place.
 Please find our official docs [here](https://miranum.com/docs/components/miranum-ide/intro-miranum-ide).
 
 
-The Miranum Modeler is one component of our collection of *VS Code Plugins*.
-It allows you to model BPMN 2.0 Diagrams that can be used with Camunda Platform 7.
+Miranum Forms is one component of our collection of *VS Code Plugins*.
+This allows you to create and edit forms based on [JSON Schema](https://json-schema.org/),
+a specification for annotating and validating JSON documents. 
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ## Features
 
-* Create and edit processes for Camunda Platform 7 and enhance them with technical attributes.
-* Use the text editor for changes directly in the XML file.
-* Use the integrated *Token Simulation* to simulate your process flow.
+* Create and edit forms that you can reference in your User Tasks of your BPMN diagram.
+* Use Switches, Multiselect, Dates, and many other fields to create your unique form.
+* Display and test your form with a build in form renderer.
+* Use the text editor for changes directly in the JSON file
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ### Built With
 
-The documentation project is built with technologies we use in our projects:
-
-* [BPMN.io](https://bpmn.io/toolkit/bpmn-js/)
+* [DigiWF Form Builder](https://github.com/it-at-m/digiwf-core/tree/dev/digiwf-apps/packages/components/digiwf-form-builder)
+* [DigiWF Form Renderer](https://github.com/it-at-m/digiwf-core/tree/dev/digiwf-apps/packages/components/digiwf-form-renderer)
+* [Vue 2](https://vuejs.org/)
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/apps/miranum-forms/package.json
+++ b/apps/miranum-forms/package.json
@@ -3,11 +3,16 @@
   "displayName": "Miranum: Form Builder",
   "description": "Edit JSON Schema files with an modern easy to use editor.",
   "license": "Apache License 2.0",
-  "version": "0.3.3",
+  "version": "0.1.0",
   "publisher": "miragon-gmbh",
+  "homepage": "https://www.miranum.io/",
+  "galleryBanner": {
+    "color": "#4254E2",
+    "theme": "dark"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/FlowSquad/miranum-ide/tree/main/apps/miranum-forms"
+    "url": "https://github.com/FlowSquad/miranum-ide.git"
   },
   "bugs": {
     "url": "https://github.com/FlowSquad/miranum-ide/issues"
@@ -17,8 +22,16 @@
   },
   "icon": "assets/kometLogo.png",
   "categories": [
-    "Other",
-    "Visualization"
+    "Other", "Visualization"
+  ],
+  "extensionPack": [
+    "miragon-gmbh.miranum-console",
+    "miragon-gmbh.miranum-json-forms",
+    "miragon-gmbh.miranum-vs-code-forms",
+    "miragon-gmbh.vs-code-bpmn-modeler"
+  ],
+  "keywords": [
+    "JSON", "JSON Schema", "Forms", "Formbuilder", "Renderer", "rendering"
   ],
   "main": "main.js",
   "activationEvents": [

--- a/apps/miranum-forms/project.json
+++ b/apps/miranum-forms/project.json
@@ -63,11 +63,11 @@
         "generatePackageJson": true,
         "webpackConfig": "apps/miranum-forms/custom-webpack.config.js",
         "assets": [
-          { "glob": "images/logo_miranum-forms.png", "input": "./", "output": "/assets" },
           { "glob": "images/komet.svg", "input": "./", "output": "/assets" },
           { "glob": "images/kometLogo.png", "input": "./", "output": "/assets" },
+          { "glob": "LICENSE", "input": "./", "output": "/" },
           { "glob": ".vscodeignore", "input": "./apps/miranum-forms/", "output": "/" },
-          { "glob": "LICENSE", "input": "./", "output": "/" }
+          { "glob": "README.md", "input": "./apps/miranum-forms/", "output": "/" }
         ]
       },
       "configurations": {

--- a/apps/miranum-modeler/package.json
+++ b/apps/miranum-modeler/package.json
@@ -6,6 +6,10 @@
   "version": "0.1.0",
   "publisher": "miragon-gmbh",
   "homepage": "https://www.miranum.io/",
+  "galleryBanner": {
+    "color": "#4254E2",
+    "theme": "dark"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/FlowSquad/miranum-ide.git"
@@ -18,13 +22,16 @@
   },
   "icon": "assets/kometLogo.png",
   "categories": [
-    "Visualization",
-    "Other"
+    "Visualization", "Other"
+  ],
+  "extensionPack": [
+    "miragon-gmbh.miranum-console",
+    "miragon-gmbh.miranum-json-forms",
+    "miragon-gmbh.miranum-vs-code-forms",
+    "miragon-gmbh.vs-code-bpmn-modeler"
   ],
   "keywords": [
-    "BPMN",
-    "Modeler",
-    "Camunda"
+    "BPMN", "Modeler", "Camunda", "Diagram", "business process"
   ],
   "activationEvents": [
     "onCustomEditor:bpmn-modeler",


### PR DESCRIPTION
**Issue**
Currently, no information about the respective plugin is displayed on the pages of our extensions in the VS Code Marketplace.

**Description**
Add a basic README to each of our extensions.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
