### PR TITLE
feat(extensions): create extension pack

### DIFF
--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -59,8 +59,8 @@ jobs:
           cd ../miranum-modeler
           npm install -g @vscode/vsce@latest
           vsce package
+      - run: cd ..
       - uses: actions/upload-artifact@v3
-        run: cd ..
         with:
           name: vsix-packages
           path: dist

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -39,26 +39,24 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: dist
+      - name: install vsce
+        run: npm install -g @vscode/vsce@latest
       - name: Build vsix miranum-extension-pack
         run: |
           cd apps/miranum-extension-pack
-          npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-console
         run: |
           cd apps/miranum-console
-          npm install -g @vscode/vsce@latest
-          vsce package
+          vsce package --no-dependencies
       - name: Build vsix miranum-forms
         run: |
           cd apps/miranum-forms
-          npm install -g @vscode/vsce@latest
-          vsce package
+          vsce package --no-dependencies
       - name: Build vsix miranum-modeler
         run: |
           cd apps/miranum-modeler
-          npm install -g @vscode/vsce@latest
-          vsce package
+          vsce package --no-dependencies
       - name: collect vsix
         run: |
           mkdir vsix-packages

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -41,6 +41,7 @@ jobs:
           name: dist
       - name: Build vsix miranum-extension-pack
         run: |
+          pwd
           cd dist/apps/miranum-extension-pack
           npm install -g @vscode/vsce@latest
           vsce package

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -46,6 +46,7 @@ jobs:
           vsce package
       - name: Build vsix miranum-console
         run: |
+          ls -Rla
           cd ../miranum-console
           npm install -g @vscode/vsce@latest
           vsce package

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -46,25 +46,23 @@ jobs:
           vsce package
       - name: Build vsix miranum-console
         run: |
-          ls -Rla
-          cd ../miranum-console
+          cd apps/miranum-console
           npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-forms
         run: |
-          cd ../miranum-forms
+          cd apps/miranum-forms
           npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-modeler
         run: |
-          cd ../miranum-modeler
+          cd apps/miranum-modeler
           npm install -g @vscode/vsce@latest
           vsce package
       - name: collect vsix
         run: |
-          cd ..
           mkdir vsix-packages
-          cp -r ./*.vsix vsix-packages/.
+          find . -name "*.vsix" -type f -exec cp {} vsix-packages \;
       - uses: actions/upload-artifact@v3
         with:
           name: vsix-packages

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -41,8 +41,7 @@ jobs:
           name: dist
       - name: Build vsix miranum-extension-pack
         run: |
-          ls -Rla
-          cd dist/apps/miranum-extension-pack
+          cd apps/miranum-extension-pack
           npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-console
@@ -60,8 +59,12 @@ jobs:
           cd ../miranum-modeler
           npm install -g @vscode/vsce@latest
           vsce package
-      - run: cd ../..
+      - name: collect vsix
+        run: |
+          cd ..
+          mkdir vsix-packages
+          cp -r ./*.vsix vsix-packages/.
       - uses: actions/upload-artifact@v3
         with:
           name: vsix-packages
-          path: dist
+          path: vsix-packages

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -25,3 +25,39 @@ jobs:
         with:
           name: dist
           path: dist
+
+  vsce-package:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Setup NodeJS 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+      - name: Prepare
+        run: npm install && npm install -g @vscode/vsce@latest
+      - name: Build vsix miranum-extension-pack
+        run: |
+          cd dist/miranum-extension-pack
+          vsce package
+      - name: Build vsix miranum-console
+        run: |
+          cd ../miranum-console
+          vsce package --out miranum-console.vsix
+      - name: Build vsix miranum-forms
+        run: |
+          cd ../miranum-forms
+          vsce package --out miranum-console.vsix
+      - name: Build vsix miranum-modeler
+        run: |
+          cd ../miranum-modeler
+          vsce package --out miranum-console.vsix
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vsix-packages
+          path: dist

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -39,25 +39,25 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: dist
-      - name: install vsce
+      - name: Install vsce
         run: npm install -g @vscode/vsce@latest
       - name: Build vsix miranum-extension-pack
         run: |
           cd apps/miranum-extension-pack
-          vsce package
+          vsce package --out miranum-extension-pack.vsix
       - name: Build vsix miranum-console
         run: |
           cd apps/miranum-console
-          vsce package --no-dependencies
+          vsce package --no-dependencies --out miranum-console.vsix
       - name: Build vsix miranum-forms
         run: |
           cd apps/miranum-forms
-          vsce package --no-dependencies
+          vsce package --no-dependencies --out miranum-forms.vsix
       - name: Build vsix miranum-modeler
         run: |
           cd apps/miranum-modeler
-          vsce package --no-dependencies
-      - name: collect vsix
+          vsce package --no-dependencies --out miranum-modeler.vsix
+      - name: Collect vsix
         run: |
           mkdir vsix-packages
           find . -name "*.vsix" -type f -exec cp {} vsix-packages \;

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -41,8 +41,8 @@ jobs:
           name: dist
       - name: Build vsix miranum-extension-pack
         run: |
-          cd dist/miranum-extension-pack
-          npm install && npm install -g @vscode/vsce@latest
+          cd dist/apps/miranum-extension-pack
+          npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-console
         run: |
@@ -59,7 +59,7 @@ jobs:
           cd ../miranum-modeler
           npm install -g @vscode/vsce@latest
           vsce package
-      - run: cd ..
+      - run: cd ../..
       - uses: actions/upload-artifact@v3
         with:
           name: vsix-packages

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -41,7 +41,7 @@ jobs:
           name: dist
       - name: Build vsix miranum-extension-pack
         run: |
-          pwd
+          ls -Rla
           cd dist/apps/miranum-extension-pack
           npm install -g @vscode/vsce@latest
           vsce package

--- a/.github/workflows/dry-release.yml
+++ b/.github/workflows/dry-release.yml
@@ -39,25 +39,28 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: dist
-      - name: Prepare
-        run: npm install && npm install -g @vscode/vsce@latest
       - name: Build vsix miranum-extension-pack
         run: |
           cd dist/miranum-extension-pack
+          npm install && npm install -g @vscode/vsce@latest
           vsce package
       - name: Build vsix miranum-console
         run: |
           cd ../miranum-console
-          vsce package --out miranum-console.vsix
+          npm install -g @vscode/vsce@latest
+          vsce package
       - name: Build vsix miranum-forms
         run: |
           cd ../miranum-forms
-          vsce package --out miranum-console.vsix
+          npm install -g @vscode/vsce@latest
+          vsce package
       - name: Build vsix miranum-modeler
         run: |
           cd ../miranum-modeler
-          vsce package --out miranum-console.vsix
+          npm install -g @vscode/vsce@latest
+          vsce package
       - uses: actions/upload-artifact@v3
+        run: cd ..
         with:
           name: vsix-packages
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release Tag'
         required: true
         default: 'release/XXX'
+      miranum-extension-pack:
+        description: 'Release miranum-extension-pack app (y/n)?'
+        required: true
+        default: 'y'
       miranum-cli:
         description: 'Release miranum-cli app (y/n)?'
         required: true
@@ -55,6 +59,11 @@ jobs:
         with:
           name: miranum-cli
           path: dist/apps/miranum-cli
+      # miranum-extension-pack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: miranum-extension-pack
+          path: dist/apps/miranum-extension-pack
       # miranum-console
       - uses: actions/upload-artifact@v3
         with:
@@ -107,6 +116,29 @@ jobs:
           release_name: Release ${{ github.event.inputs.release-tag }}
           draft: false
           prerelease: false
+
+  # miranum-extension-pack
+  publish-miranum-extension-pack:
+    if: github.event.inputs.miranum-extension-pack == 'y'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - create-release
+    steps:
+      - name: Setup NodeJS 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v3
+        with:
+          name: miranum-extension-pack
+      - name: Prepare
+        run: npm install && npm install -g @vscode/vsce@latest
+      - name: Publish extension
+        run: vsce publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
 
   # miranum-console
   publish-miranum-console:

--- a/apps/miranum-console/README.md
+++ b/apps/miranum-console/README.md
@@ -52,7 +52,6 @@ Furthermore, please have a look to our [Code of Conduct](https://miranum.com/doc
 
 Distributed under the [Apache License Version 2.0](https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE).
 
-<p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/apps/miranum-console/package.json
+++ b/apps/miranum-console/package.json
@@ -24,12 +24,6 @@
 	"categories": [
 		"Other"
 	],
-  "extensionPack": [
-    "miragon-gmbh.miranum-console",
-    "miragon-gmbh.miranum-json-forms",
-    "miragon-gmbh.miranum-vs-code-forms",
-    "miragon-gmbh.vs-code-bpmn-modeler"
-  ],
   "keywords": [
     "deploy", "Deployment", "CLI", "fontend"
   ],

--- a/apps/miranum-extension-pack/.env.build
+++ b/apps/miranum-extension-pack/.env.build
@@ -1,0 +1,1 @@
+MIRANUM_EXT_PACK_OUTPUT_DIR="dist/apps/miranum-extension-pack"

--- a/apps/miranum-extension-pack/README.md
+++ b/apps/miranum-extension-pack/README.md
@@ -1,0 +1,64 @@
+<div id="top"></div>
+
+<!-- PROJECT SHIELDS -->
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+<!-- END OF PROJECT SHIELDS -->
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+    <a href="#">
+        <img src="https://raw.githubusercontent.com/FlowSquad/miranum-ide/main/images/miranum_logo.png" alt="Logo" height="120">
+    </a>
+    <h3 ><a href="https://miranum.com/">Miranum IDE</a> <i>by <a href="https://miragon.io/">Miragon</a></i></h3>
+    <p>
+        <i>One IDE for everything!</i>
+        <br />
+        <a href="https://github.com/FlowSquad/miranum-ide/issues">Report Bug</a>
+        ·
+        <a href="https://github.com/FlowSquad/miranum-ide/pulls">Request Feature</a>
+    </p>
+</div>
+
+
+## About The Project [![Version][version-shield]][version-url] [![Installs][installs-shield]][installs-url]
+
+Miranum IDE is a collection of *VS Code Plugins* that allows you to edit, manage and access all artifacts for your 
+process application in one place.
+Please find our official docs [here](https://miranum.com/docs/components/miranum-ide/intro-miranum-ide).
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to learn, inspire, and create.
+Any contributions you make are **greatly appreciated**.
+
+For more information of the frameworks we use and how to contribute to our project see [here](https://github.com/FlowSquad/miranum-ide/blob/main/README.md).  
+Furthermore, please have a look to our [Code of Conduct](https://miranum.com/docs/components/contributing/).
+
+### License
+
+Distributed under the [Apache License Version 2.0](https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE).
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+[contributors-shield]: https://img.shields.io/github/contributors/FlowSquad/miranum-ide.svg?style=for-the-badge
+[contributors-url]: https://github.com/FlowSquad/miranum-ide/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/FlowSquad/miranum-ide.svg?style=for-the-badge
+[forks-url]: https://github.com/FlowSquad/miranum-ide/network/members
+[stars-shield]: https://img.shields.io/github/stars/FlowSquad/miranum-ide.svg?style=for-the-badge
+[stars-url]: https://github.com/FlowSquad/miranum-ide/stargazers
+[issues-shield]: https://img.shields.io/github/issues/FlowSquad/miranum-ide.svg?style=for-the-badge
+[issues-url]: https://github.com/FlowSquad/miranum-ide/issues
+[license-shield]: https://img.shields.io/github/license/FlowSquad/miranum-ide.svg?style=for-the-badge
+[license-url]: https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE
+
+[version-shield]: https://img.shields.io/visual-studio-marketplace/v/miragon-gmbh.miranum-ide
+[version-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.miranum-ide
+[installs-shield]: https://img.shields.io/visual-studio-marketplace/i/miragon-gmbh.miranum-ide
+[installs-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.miranum-ide

--- a/apps/miranum-extension-pack/README.md
+++ b/apps/miranum-extension-pack/README.md
@@ -43,7 +43,6 @@ Furthermore, please have a look to our [Code of Conduct](https://miranum.com/doc
 
 Distributed under the [Apache License Version 2.0](https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE).
 
-<p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/apps/miranum-extension-pack/package.json
+++ b/apps/miranum-extension-pack/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "miranum-ide",
+  "displayName": "Miranum IDE",
+  "description": "One IDE for everything!",
+  "license": "Apache License 2.0",
+  "version": "0.1.0",
+  "publisher": "miragon-gmbh",
+  "homepage": "https://www.miranum.io/",
+  "galleryBanner": {
+    "color": "#F0F8FF",
+    "theme": "light"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FlowSquad/miranum-ide.git"
+  },
+  "bugs": {
+    "url": "https://github.com/FlowSquad/miranum-ide/issues"
+  },
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "icon": "miranum_logo.png",
+  "extensionPack": [
+    "miragon-gmbh.miranum-console",
+    "miragon-gmbh.miranum-json-forms",
+    "miragon-gmbh.miranum-vs-code-forms",
+    "miragon-gmbh.vs-code-bpmn-modeler"
+  ],
+  "keywords": [
+    "IDE", "Bussiness Process Management", "BPMN", "Camunda", "JSON", "JSON Schema", "Forms", "Formbuilder"
+  ],
+  "categories": [
+    "Extension Packs"
+  ]
+}

--- a/apps/miranum-extension-pack/project.json
+++ b/apps/miranum-extension-pack/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "miranum-extension-pack",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/miranum-extension-pack/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "mkdir -p $MIRANUM_EXT_PACK_OUTPUT_DIR",
+          "rsync -avz --exclude=project.json --exclude=.env.build apps/miranum-extension-pack/ $MIRANUM_EXT_PACK_OUTPUT_DIR/",
+          "cp images/miranum_logo.png $MIRANUM_EXT_PACK_OUTPUT_DIR",
+          "cp LICENSE $MIRANUM_EXT_PACK_OUTPUT_DIR"
+        ],
+        "parallel": false
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/miranum-forms/README.md
+++ b/apps/miranum-forms/README.md
@@ -55,7 +55,6 @@ Furthermore, please have a look to our [Code of Conduct](https://miranum.com/doc
 
 Distributed under the [Apache License Version 2.0](https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE).
 
-<p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/apps/miranum-forms/package.json
+++ b/apps/miranum-forms/package.json
@@ -24,12 +24,6 @@
   "categories": [
     "Other", "Visualization"
   ],
-  "extensionPack": [
-    "miragon-gmbh.miranum-console",
-    "miragon-gmbh.miranum-json-forms",
-    "miragon-gmbh.miranum-vs-code-forms",
-    "miragon-gmbh.vs-code-bpmn-modeler"
-  ],
   "keywords": [
     "JSON", "JSON Schema", "Forms", "Formbuilder", "Renderer", "rendering"
   ],

--- a/apps/miranum-modeler/README.md
+++ b/apps/miranum-modeler/README.md
@@ -53,7 +53,6 @@ Furthermore, please have a look to our [Code of Conduct](https://miranum.com/doc
 
 Distributed under the [Apache License Version 2.0](https://github.com/FlowSquad/miranum-ide/blob/main/LICENSE).
 
-<p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/apps/miranum-modeler/package.json
+++ b/apps/miranum-modeler/package.json
@@ -24,12 +24,6 @@
   "categories": [
     "Visualization", "Other"
   ],
-  "extensionPack": [
-    "miragon-gmbh.miranum-console",
-    "miragon-gmbh.miranum-json-forms",
-    "miragon-gmbh.miranum-vs-code-forms",
-    "miragon-gmbh.vs-code-bpmn-modeler"
-  ],
   "keywords": [
     "BPMN", "Modeler", "Camunda", "Diagram", "business process"
   ],

--- a/workspace.json
+++ b/workspace.json
@@ -7,6 +7,7 @@
     "miranum-console-webview": "apps/miranum-console-webview",
     "miranum-core": "libs/miranum-core",
     "miranum-deployment-proxy": "spring-boot-apps/miranum-deployment-proxy",
+    "miranum-extension-pack": "apps/miranum-extension-pack",
     "miranum-forms": "apps/miranum-forms",
     "miranum-forms-webview": "apps/miranum-forms-webview",
     "miranum-modeler": "apps/miranum-modeler",


### PR DESCRIPTION
**Issue**
Currently we have four extensions released on the VS Code Marketplace. We want an extension pack that installs all our available extensions.

**Description**
* Create a Extension Pack
* Update release pipeline

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
